### PR TITLE
fix error twig : Key 'dragsort' for array with keys ... does not exist

### DIFF
--- a/templates/_sub/_record_list.twig
+++ b/templates/_sub/_record_list.twig
@@ -20,7 +20,7 @@
     {% endset %}
 
     {% if not async %}
-        <div class="buic-listing {% if contenttype.dragsort %}dragsort{% endif %}" data-showing-from="{{ pager.showingFrom }}" data-bolt-widget="buicListing" data-contenttype="{{ contenttype.slug }}" data-contenttype-name="{{ contenttype.singular_name }}" data-bolt_csrf_token="{{ token() }}">
+        <div class="buic-listing {% if contenttype.dragsort is defined %}dragsort{% endif %}" data-showing-from="{{ pager.showingFrom }}" data-bolt-widget="buicListing" data-contenttype="{{ contenttype.slug }}" data-contenttype-name="{{ contenttype.singular_name }}" data-bolt_csrf_token="{{ token() }}">
     {% endif %}
         <table class="{{ extra_classes }} dashboardlisting listing">
             {% for content in multiplecontent %}


### PR DESCRIPTION
fix an error twig : Key 'dragsort' for array with keys ... does not exist
The error appear when we display an overview page without dragsort.