### PR TITLE
Fixes variable "pager" not existing in template

### DIFF
--- a/templates/_sub/_record_list.twig
+++ b/templates/_sub/_record_list.twig
@@ -20,7 +20,7 @@
     {% endset %}
 
     {% if not async %}
-        <div class="buic-listing {% if contenttype.dragsort is defined %}dragsort{% endif %}" data-showing-from="{{ pager.showingFrom }}" data-bolt-widget="buicListing" data-contenttype="{{ contenttype.slug }}" data-contenttype-name="{{ contenttype.singular_name }}" data-bolt_csrf_token="{{ token() }}" data-admin-path="{{ path('dashboard') }}">
+	<div class="buic-listing {% if contenttype.dragsort is defined %}dragsort{% endif %}" data-showing-from="{% if pager is defined %}{{ pager.showingFrom }}{% endif %}" data-bolt-widget="buicListing" data-contenttype="{{ contenttype.slug }}" data-contenttype-name="{{ contenttype.singular_name }}" data-bolt_csrf_token="{{ token() }}" data-admin-path="{{ path('dashboard') }}">
     {% endif %}
         <table class="{{ extra_classes }} dashboardlisting listing">
             {% for content in multiplecontent %}


### PR DESCRIPTION
I got an the following Twig_Runtime_Error when loading the overview pages: `Variable "pager" does not exist in "@bolt/_sub/_record_list.twig" at line 23.`

Checking whether variable exists fixes this for me. Hope it works for you too.